### PR TITLE
ERR FIX: Model repeats itself, looping over the same summary output

### DIFF
--- a/src/components/Summarizer/Summarizer.tsx
+++ b/src/components/Summarizer/Summarizer.tsx
@@ -63,6 +63,7 @@ const Summarizer = () => {
         }
 
         const chatData: Chat[] = JSON.parse(storedData);
+        console.log('Chat data:', chatData);
         await generateSummary(chatData);
       } catch (error) {
         console.error('Initialization error:', error);
@@ -99,19 +100,21 @@ const Summarizer = () => {
           coverage: `${percentageCovered}%`
         }
       };
-      console.log('Chat input:', chatInput);
+      console.log('Chat input:', chatInput.messages);
       const response = await engineRef.current.chat.completions.create({
         messages: [
           SYSTEM_PROMPT,
           { role: 'user', content: JSON.stringify(chatInput.messages) }
         ],
         temperature: 0.1,
-        max_tokens: 800,
+        frequency_penalty: 1.0,
+        max_completion_tokens: 400,
         response_format: { type: "json_object" }
       });
-      console.log('Summary response:', response);
+      console.log('Summary response:', response.choices[0].message.content);
 
       const summaryObj = JSON.parse(response.choices[0].message.content);
+      
       setSummary(JSON.stringify({
         ...summaryObj,
       }, null, 2));


### PR DESCRIPTION
Sometimes I see the following issue show up (not really reproducible and adds to unreliable nature of current implementation): 

<img width="720" alt="Screenshot 2024-11-29 at 11 17 00 AM" src="https://github.com/user-attachments/assets/cc8dd234-af09-482b-a453-f199c2e17a22">

Here, the model is repeating the same output tokens over and over in a loop. Using frequency_penalty from https://platform.openai.com/docs/api-reference/chat decreases the model's lieklihood to repeat itself in the summary output.