### PR TITLE
Better context window calcuation

### DIFF
--- a/src/components/Summarizer/Summarizer.tsx
+++ b/src/components/Summarizer/Summarizer.tsx
@@ -4,7 +4,7 @@ import type { Chat } from '../../scripts/jsonToLLM.ts';
 import { optimizeChatsForLLM } from '../../scripts/jsonToLLM.ts';
 import SummaryCard from './SummaryCard';
 
-const CONTEXT_WINDOW = 2500; // setting a conservative context window (max no of tokens the model can process at once)
+const CONTEXT_WINDOW = 3800; // setting a conservative context window (max no of tokens the model can process at once)
 const MODEL_NAME = "Qwen2.5-1.5B-Instruct-q4f16_1-MLC";
 
 const DEFAULT_SUMMARY = {


### PR DESCRIPTION
Previously...
- estimateTokens implemenation was done using character length / 4
- No accounting for system prompts or JSON structure overhead

Changes made...
- token estimation to account for special chars and boundaries
- explicit reservations for system prompt (150 tokens) and JSON structure (50 tokens)
- 10% safety margin for token calculations

Previosuly, it was not working since we were estimating tokens by dividing string length by 4:

`Math.ceil(JSON.stringify(message).length / 4)`

We also were not explicitly accounting for system prompts or JSON structure tokens. 

Now it works for all file sizes on our gdrive.